### PR TITLE
Configuration extended with primary knowledge base specification.

### DIFF
--- a/odalic/src/main/java/cz/cuni/mff/xrg/odalic/api/rest/resources/ConfigurationResource.java
+++ b/odalic/src/main/java/cz/cuni/mff/xrg/odalic/api/rest/resources/ConfigurationResource.java
@@ -45,9 +45,9 @@ public final class ConfigurationResource {
     
     final Configuration configuration;
     if (configurationValue.getFeedback() == null) {
-      configuration = new Configuration(input);
+        configuration = new Configuration(input, configurationValue.getPrimaryBase());
     } else {
-      configuration = new Configuration(input, configurationValue.getFeedback());
+      configuration = new Configuration(input, configurationValue.getPrimaryBase(), configurationValue.getFeedback());
     }
 
     configurationService.setForTaskId(id, configuration);

--- a/odalic/src/main/java/cz/cuni/mff/xrg/odalic/api/rest/resources/TaskResource.java
+++ b/odalic/src/main/java/cz/cuni/mff/xrg/odalic/api/rest/resources/TaskResource.java
@@ -70,8 +70,8 @@ public final class TaskResource {
   public Response putTaskWithId(@Context UriInfo uriInfo, @PathParam("id") String id, TaskValue taskValue) throws MalformedURLException {
     final ConfigurationValue configurationValue = taskValue.getConfiguration();
     final File input = fileService.getById(configurationValue.getInput());
-    final Configuration configuration = new Configuration(input, configurationValue.getFeedback());
-    final Task task = new Task(taskValue.getId(), taskValue.getCreated(), new Configuration(input, configuration.getFeedback()));
+    final Configuration configuration = new Configuration(input, configurationValue.getPrimaryBase(), configurationValue.getFeedback());
+    final Task task = new Task(taskValue.getId(), taskValue.getCreated(), configuration);
     
     if (!taskService.hasId(task, id)) {
       return Response.status(Response.Status.NOT_ACCEPTABLE)

--- a/odalic/src/main/java/cz/cuni/mff/xrg/odalic/api/rest/values/ConfigurationValue.java
+++ b/odalic/src/main/java/cz/cuni/mff/xrg/odalic/api/rest/values/ConfigurationValue.java
@@ -29,7 +29,7 @@ public final class ConfigurationValue implements Serializable {
   @XmlElement(name = "feedback")
   private Feedback feedback;
   
-  @XmlElement(name = "primaryBase")
+  @XmlElement(name = "primary_base")
   private KnowledgeBase primaryBase;
 
   public ConfigurationValue() {}

--- a/odalic/src/main/java/cz/cuni/mff/xrg/odalic/api/rest/values/ConfigurationValue.java
+++ b/odalic/src/main/java/cz/cuni/mff/xrg/odalic/api/rest/values/ConfigurationValue.java
@@ -9,6 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import com.google.common.base.Preconditions;
 
 import cz.cuni.mff.xrg.odalic.feedbacks.Feedback;
+import cz.cuni.mff.xrg.odalic.tasks.annotations.KnowledgeBase;
 import cz.cuni.mff.xrg.odalic.tasks.configurations.Configuration;
 
 /**
@@ -27,12 +28,16 @@ public final class ConfigurationValue implements Serializable {
 
   @XmlElement(name = "feedback")
   private Feedback feedback;
+  
+  @XmlElement(name = "primaryBase")
+  private KnowledgeBase primaryBase;
 
   public ConfigurationValue() {}
 
   public ConfigurationValue(Configuration adaptee) {
     input = adaptee.getInput().getId();
     feedback = adaptee.getFeedback();
+    primaryBase = adaptee.getPrimaryBase();
   }
 
   /**
@@ -70,11 +75,29 @@ public final class ConfigurationValue implements Serializable {
     this.feedback = feedback;
   }
 
+  /**
+   * @return the primary knowledge base
+   */
+  @Nullable
+  public KnowledgeBase getPrimaryBase() {
+    return primaryBase;
+  }
+
+  /**
+   * @param primaryBase the primary knowledge base to set
+   */
+  public void setPrimaryBase(KnowledgeBase primaryBase) {
+    Preconditions.checkNotNull(primaryBase);
+    
+    this.primaryBase = primaryBase;
+  }
+
   /* (non-Javadoc)
    * @see java.lang.Object#toString()
    */
   @Override
   public String toString() {
-    return "ConfigurationValue [input=" + input + ", feedback=" + feedback + "]";
+    return "ConfigurationValue [input=" + input + ", feedback=" + feedback + ", primaryBase="
+        + primaryBase + "]";
   }
 }

--- a/odalic/src/main/java/cz/cuni/mff/xrg/odalic/tasks/configurations/Configuration.java
+++ b/odalic/src/main/java/cz/cuni/mff/xrg/odalic/tasks/configurations/Configuration.java
@@ -10,6 +10,7 @@ import com.google.common.base.Preconditions;
 import cz.cuni.mff.xrg.odalic.api.rest.adapters.ConfigurationAdapter;
 import cz.cuni.mff.xrg.odalic.feedbacks.Feedback;
 import cz.cuni.mff.xrg.odalic.files.File;
+import cz.cuni.mff.xrg.odalic.tasks.annotations.KnowledgeBase;
 
 /**
  * Task configuration.
@@ -26,30 +27,32 @@ public final class Configuration implements Serializable {
   private final File input; 
 
   private final Feedback feedback;
+  
+  private final KnowledgeBase primaryBase;
 
   /**
    * Creates configuration without any feedback, thus implying fully automatic processing.
    * 
    * @param input input specification
    */
-  public Configuration(File input) {
-    Preconditions.checkNotNull(input);
-    
-    this.input = input;
-    this.feedback = new Feedback();
+  public Configuration(File input, KnowledgeBase primaryBase) {
+    this(input, primaryBase, new Feedback());
   }
   
   /**
    * Creates configuration with provided feedback, which serves as hint for the processing algorithm.
    * 
    * @param input input specification
+   * @param primaryBase primary knowledge base
    * @param feedback constraints for the algorithm
    */
-  public Configuration(File input, Feedback feedback) {
+  public Configuration(File input, KnowledgeBase primaryBase, Feedback feedback) {
     Preconditions.checkNotNull(input);
+    Preconditions.checkNotNull(primaryBase);
     Preconditions.checkNotNull(feedback);
     
     this.input = input;
+    this.primaryBase = primaryBase;
     this.feedback = feedback;
   }
 
@@ -65,6 +68,13 @@ public final class Configuration implements Serializable {
    */
   public Feedback getFeedback() {
     return feedback;
+  }
+
+  /**
+   * @return the primary knowledge base
+   */
+  public KnowledgeBase getPrimaryBase() {
+    return primaryBase;
   }
 
   /* (non-Javadoc)

--- a/odalic/src/main/java/cz/cuni/mff/xrg/odalic/tasks/feedbacks/MemoryOnlyFeedbackService.java
+++ b/odalic/src/main/java/cz/cuni/mff/xrg/odalic/tasks/feedbacks/MemoryOnlyFeedbackService.java
@@ -48,7 +48,7 @@ public final class MemoryOnlyFeedbackService implements FeedbackService {
   @Override
   public void setForTaskId(String taskId, Feedback feedback) {
     final Configuration oldConfiguration = configurationService.getForTaskId(taskId);
-    configurationService.setForTaskId(taskId, new Configuration(oldConfiguration.getInput(), feedback));
+    configurationService.setForTaskId(taskId, new Configuration(oldConfiguration.getInput(), oldConfiguration.getPrimaryBase(), feedback));
   }
 
   @Override


### PR DESCRIPTION
The client has to provide a field primaryBase in every task configuration object containing a KB object (this object contains only name attribute with the name of the KB).