### PR TITLE
Double quotes made the default choice as quoting character.

### DIFF
--- a/odalic/src/main/java/cz/cuni/mff/xrg/odalic/files/formats/Format.java
+++ b/odalic/src/main/java/cz/cuni/mff/xrg/odalic/files/formats/Format.java
@@ -94,7 +94,7 @@ public final class Format {
     charset = StandardCharsets.UTF_8;
     delimiter = ';';
     emptyLinesIgnored = true;
-    quoteCharacter = null;
+    quoteCharacter = '"';
     escapeCharacter = null;
     commentMarker = null;
     lineSeparator = System.lineSeparator();


### PR DESCRIPTION
Fixes #311 .