### PR TITLE
find attributes faster - get labels in one query

### DIFF
--- a/sti-kbproxy/src/main/java/uk/ac/shef/dcs/kbproxy/model/Attribute.java
+++ b/sti-kbproxy/src/main/java/uk/ac/shef/dcs/kbproxy/model/Attribute.java
@@ -22,9 +22,11 @@ public abstract class Attribute implements Serializable {
   // is used to indicate whether the attribute is a direct attribute of the resource or not
 
 
-  public Attribute(String relationURI, String value) {
+  public Attribute(String relationLabel, String relationURI, String value, String valueURI) {
+    this.relationLabel = relationLabel;
     this.relationURI = relationURI;
     this.value = fixValue(value);
+    this.valueURI = valueURI;
   }
 
   // TODO: Fix the dependency on KBDefinition

--- a/sti-kbproxy/src/main/java/uk/ac/shef/dcs/kbproxy/sparql/SparqlAttribute.java
+++ b/sti-kbproxy/src/main/java/uk/ac/shef/dcs/kbproxy/sparql/SparqlAttribute.java
@@ -14,8 +14,8 @@ public class SparqlAttribute extends Attribute {
 
   private static final long serialVersionUID = -1365433077663956951L;
 
-  public SparqlAttribute(String relationURI, String value) {
-    super(relationURI, value);
+  public SparqlAttribute(String relationLabel, String relationURI, String value, String valueURI) {
+    super(relationLabel, relationURI, value, valueURI);
   }
 
   @Override

--- a/sti-kbproxy/src/main/java/uk/ac/shef/dcs/kbproxy/sparql/helpers/SelectBuilder.java
+++ b/sti-kbproxy/src/main/java/uk/ac/shef/dcs/kbproxy/sparql/helpers/SelectBuilder.java
@@ -15,8 +15,10 @@ public class SelectBuilder {
   private Map<String, String> prefixes = new HashMap<>();
   private Set<String> variables = new HashSet<>();
   private List<SelectBuilder> unions = new ArrayList<>();
+  private List<SelectBuilder> optionals = new ArrayList<>();
   private List<SelectBuilder> subExpressions = new ArrayList<>();
   private List<WhereExpression> whereExpressions = new ArrayList<>();
+  private List<String> valuesClauses = new ArrayList<>();
   private List<String> filters = new ArrayList<>();
 
   public SelectBuilder setDistinct(boolean isDistinct) {
@@ -44,6 +46,11 @@ public class SelectBuilder {
     return this;
   }
 
+  public SelectBuilder addOptional(SelectBuilder optionalBuilder) {
+    optionals.add(optionalBuilder);
+    return this;
+  }
+
   public SelectBuilder addSubExpression(SelectBuilder subBuilder) {
     subExpressions.add(subBuilder);
     return this;
@@ -51,6 +58,11 @@ public class SelectBuilder {
 
   public SelectBuilder addWhere(String subject, String predicate, String object) {
     whereExpressions.add(new WhereExpression(subject, predicate, object));
+    return this;
+  }
+
+  public SelectBuilder addValuesClause(String valuesClause) {
+    valuesClauses.add(valuesClause);
     return this;
   }
 
@@ -122,6 +134,21 @@ public class SelectBuilder {
       builder.append(expression.predicate);
       builder.append(" ");
       builder.append(expression.object);
+      builder.append(" .");
+      builder.append("\n");
+    });
+
+    optionals.forEach(optionalBuilder -> {
+      builder.append(innerPrefix);
+      builder.append("OPTIONAL");
+      builder.append("\n");
+      optionalBuilder.buildWhere(builder, innerPrefix, true);
+    });
+
+    valuesClauses.forEach(valuesClause -> {
+      builder.append(innerPrefix);
+      builder.append("VALUES ");
+      builder.append(valuesClause);
       builder.append(" .");
       builder.append("\n");
     });


### PR DESCRIPTION
The problem is that there are separate queries for getting label for each predicate/object of a resource in target KB, which means hundreds of queries for one disambiguation candidate. 