### PR TITLE
Correction of calling of findEntityCandidatesOfTypes

### DIFF
--- a/sti-kbproxy/src/main/java/uk/ac/shef/dcs/kbproxy/FilteringProxyCore.java
+++ b/sti-kbproxy/src/main/java/uk/ac/shef/dcs/kbproxy/FilteringProxyCore.java
@@ -122,7 +122,13 @@ public final class FilteringProxyCore implements ProxyCore {
   @Override
   public List<Entity> findEntityCandidatesOfTypes(final String content,
       final String... types) throws ProxyException {
-    return findEntityCandidatesOfTypes(content, this, types);
+    final List<Entity> result = this.core.findEntityCandidatesOfTypes(content, types);
+
+    for (Entity ec : result) {
+      filterEntityTypes(ec);
+    }
+
+    return result;
   }
   
   @Override


### PR DESCRIPTION
 (fixes caching in Update phase)

- ohledně volání SPARQL dotazů i při naplněné cache (v Update fázi): problém byl ve špatném volání CachingProxyCore z FilteringProxyCore v metodě findEntityCandidatesOfTypes - opravil jsem ve větvi CachingFix. Pak už se volají SPARQL dotazy pouze tehdy, když jejich výsledek byl prázdný a tudíž se do cache nic neuložilo (což je potvrzením toho, že při prázdném výsledku dotazu se do cache nic neukládá).